### PR TITLE
Decimals in rates edits

### DIFF
--- a/R/diagnose.R
+++ b/R/diagnose.R
@@ -165,7 +165,7 @@ check_alignment <- function(td) {
 #' @examples
 #' \donttest{
 #' data(td_single_input)
-#' 
+#'
 #' yield_sf <- sf::st_read(system.file("extdata", "yield-simple1.shp", package = "ofpetrial"))
 #' ssurgo_sf <-
 #'   sf::st_read(system.file("extdata", "ssurgo-simple1.shp", package = "ofpetrial")) %>%
@@ -300,7 +300,7 @@ summarize_indiv_char <- function(joined_data, var) {
 
     g_fig <-
       (
-        ggplot(joined_data, aes(y = rate, x = var)) +
+        ggplot(joined_data, aes(y = rate, x = as.numeric(var))) +
           geom_point() +
           ylab("Input Rate") +
           xlab(var) +

--- a/R/make_trial_report.R
+++ b/R/make_trial_report.R
@@ -804,15 +804,15 @@ make_plot_width_line <- function(trial_plot, move_vec, unit_system, all_trial_in
     if (move_vec[1] >= 0 & move_vec[2] > 0) { # when we are moving in a general NE or N direction
       point <- trial_plot_coords %>%
         data.frame(.) %>%
-        dplyr::filter(X <= median(X)) %>%
-        dplyr::filter(Y < median(Y)) %>%
-        .[1, ]
+        dplyr::mutate(XY = X + Y) %>%
+        dplyr::filter(XY == min(XY)) %>%
+        .[1, -3]
     } else if (move_vec[1] < 0 & move_vec[2] <= 0) { # SW or S direction
       point <- trial_plot_coords %>%
         data.frame(.) %>%
-        dplyr::filter(X >= median(X)) %>%
-        dplyr::filter(Y > median(Y)) %>%
-        .[1, ]
+        dplyr::mutate(XY = X + Y) %>%
+        dplyr::filter(XY == max(XY)) %>%
+        .[1, -3]
     } else if (move_vec[1] >= 0 & move_vec[2] < 0) { # SE or E direction
       point <- trial_plot_coords %>%
         data.frame(.) %>%
@@ -982,15 +982,15 @@ find_center <- function(ab_line, number_in_plot, trial_plot, move_vec, machine_i
   if (move_vec[1] >= 0 & move_vec[2] > 0) { # when we are moving in a general NE or N direction
     point <- trial_plot_coords %>%
       data.frame(.) %>%
-      dplyr::filter(X <= median(X)) %>%
-      dplyr::filter(Y < median(Y)) %>%
-      .[1, ]
+      dplyr::mutate(XY = X + Y) %>%
+      dplyr::filter(XY == min(XY)) %>%
+      .[1, -3]
   } else if (move_vec[1] < 0 & move_vec[2] <= 0) { # SW or S direction
     point <- trial_plot_coords %>%
       data.frame(.) %>%
-      dplyr::filter(X >= median(X)) %>%
-      dplyr::filter(Y > median(Y)) %>%
-      .[1, ]
+      dplyr::mutate(XY = X + Y) %>%
+      dplyr::filter(XY == max(XY)) %>%
+      .[1, -3]
   } else if (move_vec[1] >= 0 & move_vec[2] < 0) { # SE or E direction
     point <- trial_plot_coords %>%
       data.frame(.) %>%

--- a/R/utility.R
+++ b/R/utility.R
@@ -45,13 +45,23 @@ get_rates <- function(min_rate,
       }
     }
 
-    rates_low <- seq(min_rate, gc_rate, length = num_low) %>% round()
-    rates_high <- seq(gc_rate, max_rate, length = num_high) %>% round()
+    rates_low <- seq(min_rate, gc_rate, length = num_low) %>% round_rates()
+    rates_high <- seq(gc_rate, max_rate, length = num_high) %>% round_rates()
 
     rates <- c(rates_low, rates_high) %>% unique()
   }
 
   return(rates)
+}
+
+round_rates <- function(x){
+  if(median(x) > 50){
+    round(x, 0)
+  }else if(median(x) < 50 & median(x) > 10){
+    round(x, 1)
+  }else{
+    round(x, 2)
+  }
 }
 
 #++++++++++++++++++++++++++++++++++++

--- a/dev/generate_datasets.R
+++ b/dev/generate_datasets.R
@@ -244,9 +244,9 @@ input_unit_conversion_table <-
 #+ General unit conversion table
 #++++++++++++++++++++++++++++++++++++
 generic_unit_conversion_table <- data.table(
-  from = c("hectares", "acres", "meters", "feet", "kg", "pounds", "acres", "m2"),
-  to = c("acres", "hectares", "feet", "meters", "pounds", "kg", "m2", "acres"),
-  conv_factor = c(1 / 0.40468564224, 0.40468564224, 1 / 0.3048, 0.3048, 1 / 0.45359237, 0.45359237, 4046.856422, 1 / 4046.856422)
+  from = c("hectares", "acres", "meters", "feet", "kg", "pounds", "acres", "m2", "m2"),
+  to = c("acres", "hectares", "feet", "meters", "pounds", "kg", "m2", "acres", "hectares"),
+  conv_factor = c(1 / 0.40468564224, 0.40468564224, 1 / 0.3048, 0.3048, 1 / 0.45359237, 0.45359237, 4046.856422, 1 / 4046.856422, 0.0001)
 )
 
 #++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Allows for decimals in target rates and adjusts rounding based on values to not produce fewer than the desired number of distinct target levels. 
Additional change was made for diagnose vignette that was not running properly due to column lims being double in ggplot.